### PR TITLE
Fix install by updating elixir-ls-debugger path & setting $0 properly

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # asdf-elixir-ls
 
-[![GitHub Actions Status](https://github.com/juantascon/asdf-elixir-ls/actions/workflows/workflow.yml/badge.svg)](https://github.com/juantascon/asdf-elixir-ls/actions)
+[![GitHub Actions Status](../../actions/workflows/workflow.yml/badge.svg)](https://github.com/juantascon/asdf-elixir-ls/actions)
 [![GitHub license](https://img.shields.io/github/license/juantascon/asdf-elixir-ls?style=plastic)](https://github.com/juantascon/asdf-elixir-ls/blob/main/LICENSE)
 
 ## Install
 
 ```bash
-asdf plugin-add elixir https://github.com/juantascon/asdf-elixir-ls
+asdf plugin add elixir-ls https://github.com/juantascon/asdf-elixir-ls
 ```
 
 ## Use

--- a/bin/install
+++ b/bin/install
@@ -29,8 +29,19 @@ function install() {
 
   unzip "${tmp_download_dir}/${download_filename}"
   mkdir -p ./bin
-  ln -s ../language_server.sh ./bin/elixir-ls
-  ln -s ../debugger.sh ./bin/elixir-ls-debugger
+  # language_server.sh and debug_adapter.sh assume that the directory
+  # $(dirname "$0") also contains launch.sh. But we don't want to put launch.sh
+  # the PATH. So execute them using some wrappers that set $0.
+  cat <<EOF >./bin/elixir-ls
+#!/bin/sh
+exec ${install_path}/language_server.sh
+EOF
+  cat <<EOF >./bin/elixir-ls-debugger
+#!/bin/sh
+exec ${install_path}/debug_adapter.sh
+EOF
+  chmod +x ./bin/elixir-ls
+  chmod +x ./bin/elixir-ls-debugger
   cp -fpr * "${install_path}"
 
   popd >/dev/null


### PR DESCRIPTION
elixir_ls_debugger was renamed to debug_adapter in a commit to elixir-ls: https://github.com/elixir-lsp/elixir-ls/commit/27e7e8336e3749897fbf47f417fd146b8bc79b82

It also looks like language_server.sh and debug_adapter.sh want $0 to contain launch.sh as well. So install some wrappers to do that.