### PR TITLE
fix: use correct name of debugger

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -30,7 +30,7 @@ function install() {
   unzip "${tmp_download_dir}/${download_filename}"
   mkdir -p ./bin
   ln -s ../language_server.sh ./bin/elixir-ls
-  ln -s ../debugger.sh ./bin/elixir-ls-debugger
+  ln -s ../debug_adapter.sh ./bin/elixir-ls-debugger
   cp -fpr * "${install_path}"
 
   popd >/dev/null


### PR DESCRIPTION
Problem:
![image](https://github.com/user-attachments/assets/fd5162b1-84bd-44aa-aed5-d1cd3d7b96e5)

Plugin uses an incorrect name for the debug adapter - the file name has changed to debug_adapter.sh.

Solution:
If debug_adapter.sh exists, use that as the debugger. Otherwise use debugger.sh.